### PR TITLE
rate limit

### DIFF
--- a/api/src/main/kotlin/net/devslash/Definitions.kt
+++ b/api/src/main/kotlin/net/devslash/Definitions.kt
@@ -7,7 +7,7 @@ data class StrValue(val value: String) : Value()
 data class ProvidedValue(val lambda: (RequestData) -> String) : Value()
 
 interface BodyProvider
-data class Session(val calls: List<Call>, val concurrency: Int = 100, val delay: Long?)
+data class Session(val calls: List<Call>, val concurrency: Int = 100, val delay: Long?, val rateOptions: RateLimitOptions)
 
 data class Call(val url: String,
                 val headers: Map<String, List<Value>>?,
@@ -121,4 +121,4 @@ interface FullDataAfterHook : AfterHook {
 
 sealed class HttpResult<out T, out E>
 data class Success<out T>(val value: T) : HttpResult<T, Nothing>()
-data class Failure<out E: Throwable>(val err: E) : HttpResult<Nothing, E>()
+data class Failure<out E : Throwable>(val err: E) : HttpResult<Nothing, E>()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,12 +50,12 @@ subprojects {
     }
   }
 
-  tasks.withType(Test::class).configureEach {
-    useJUnitPlatform()
-    testLogging {
-      events("passed", "skipped", "failed")
-    }
-  }
+//  tasks.withType(Test::class).configureEach {
+//    useJUnitPlatform()
+//    testLogging {
+//      events("passed", "skipped", "failed")
+//    }
+//  }
 
   configure<BintrayExtension> {
     user = project.findProperty("bintrayUser") as String? ?: System.getenv("BINTRAY_USER")

--- a/extensions/build.gradle.kts
+++ b/extensions/build.gradle.kts
@@ -7,10 +7,6 @@ val mockkVersion = "1.9.3"
 val junitVersion = "4.12"
 val kotlinVersion: String by project
 
-//tasks.test test{
-//  useJUnitPlatform()
-//}useJUnitPlatform
-
 dependencies {
   compile(kotlin("stdlib", kotlinVersion))
   compile(kotlin("reflect", kotlinVersion))

--- a/extensions/build.gradle.kts
+++ b/extensions/build.gradle.kts
@@ -4,8 +4,12 @@ repositories {
 }
 
 val mockkVersion = "1.9.3"
-val junitVersion = "5.5.0"
+val junitVersion = "4.12"
 val kotlinVersion: String by project
+
+//tasks.test test{
+//  useJUnitPlatform()
+//}useJUnitPlatform
 
 dependencies {
   compile(kotlin("stdlib", kotlinVersion))
@@ -17,12 +21,11 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2")
 
   testImplementation("io.mockk:mockk:$mockkVersion")
-  testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.3.2")
+  testImplementation("junit:junit:$junitVersion")
 
   testCompile(project(":test-utils"))
   testCompile("org.hamcrest:hamcrest-core:1.3")
   testCompile("io.ktor:ktor-client-mock:1.0.0")
   testCompile("io.ktor:ktor-server-netty:1.0.0")
-  testCompile("org.junit-pioneer:junit-pioneer:0.3.0")
 }

--- a/extensions/src/test/kotlin/net/devslash/BodyProviderTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/BodyProviderTest.kt
@@ -2,8 +2,8 @@ package net.devslash
 
 import net.devslash.util.getCall
 import net.devslash.util.requestDataFromList
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import org.junit.Assert.assertEquals
+import org.junit.Test
 
 internal class BodyProviderTest {
 
@@ -15,7 +15,8 @@ internal class BodyProviderTest {
     assertEquals(EmptyBodyProvider::class, provider::class)
   }
 
-  @Test fun testWithBody() {
+  @Test
+  fun testWithBody() {
     val provider = getBodyProvider(
       getCall(HttpBody(null, mapOf("a" to listOf("b"), "c" to listOf("d")), null, null)), requestDataFromList()
     )

--- a/extensions/src/test/kotlin/net/devslash/CookieJarTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/CookieJarTest.kt
@@ -5,8 +5,7 @@ import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
+import org.junit.Test
 import java.net.URL
 
 internal class CookieJarTest {
@@ -22,7 +21,8 @@ internal class CookieJarTest {
     assertThat(standardRequest.headers["Cookie"], equalTo(listOf("A=B")))
   }
 
-  @Test fun testMultipleCaseCookieSet() {
+  @Test
+  fun testMultipleCaseCookieSet() {
     jar.accept(
         responseWithHeaders(mapOf("set-Cookie" to listOf("A=B"), "SET-COOKIE" to listOf("C=D"))))
     jar.accept(standardRequest, requestDataFromList(listOf()))

--- a/extensions/src/test/kotlin/net/devslash/DelayTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/DelayTest.kt
@@ -5,8 +5,8 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import net.devslash.data.ListDataSupplier
 import net.devslash.util.getResponseWithBody
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
+import org.junit.Assert.assertTrue
+import org.junit.Test
 
 class DelayTest {
 

--- a/extensions/src/test/kotlin/net/devslash/FileBasedDataSupplierTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/FileBasedDataSupplierTest.kt
@@ -2,8 +2,8 @@ package net.devslash
 
 import kotlinx.coroutines.runBlocking
 import net.devslash.data.FileDataSupplier
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import org.junit.Assert.assertEquals
+import org.junit.Test
 
 internal class FileBasedDataSupplierTest {
 
@@ -35,7 +35,8 @@ internal class FileBasedDataSupplierTest {
     }
   }
 
-  @Test fun testWithTabSeparator() = runBlocking {
+  @Test
+  fun testWithTabSeparator() = runBlocking {
     val path = FileDataSupplier::class.java.getResource("/tabspaced.log").path
     val dataSupplier = FileDataSupplier(path, "-")
 

--- a/extensions/src/test/kotlin/net/devslash/HttpSessionManagerTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/HttpSessionManagerTest.kt
@@ -10,13 +10,19 @@ import io.ktor.routing.routing
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
+import kotlinx.coroutines.debug.junit4.CoroutinesTimeout
 import kotlinx.coroutines.runBlocking
 import net.devslash.data.FileDataSupplier
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
 import java.util.concurrent.CountDownLatch
 
 internal class HttpSessionManagerTest : ServerTest() {
+
+  @Rule
+  @JvmField
+  public val rule = CoroutinesTimeout(5000)
 
   override lateinit var appEngine: ApplicationEngine
 
@@ -60,7 +66,8 @@ internal class HttpSessionManagerTest : ServerTest() {
     appEngine = embeddedServer(Netty, serverPort) {
       routing {
         get("/") {
-          call.respond("")
+          // this cannot be the empty string. That turns out to stuff up the blocking on response code.
+          call.respond("A")
         }
       }
     }

--- a/extensions/src/test/kotlin/net/devslash/UrlProvidersTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/UrlProvidersTest.kt
@@ -2,15 +2,15 @@ package net.devslash
 
 import net.devslash.util.getCall
 import net.devslash.util.requestDataFromList
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import org.junit.Assert.assertEquals
+import org.junit.Test
 
 internal class UrlProvidersTest {
   @Test
   fun testBasicProvider() {
     val url = "http://example.com"
     val provider = getUrlProvider(
-      getCall(url = url), requestDataFromList(listOf())
+        getCall(url = url), requestDataFromList(listOf())
     )
     assertEquals(url, provider.get())
   }
@@ -18,8 +18,8 @@ internal class UrlProvidersTest {
   @Test
   fun testReplacement() {
     val provider = getUrlProvider(
-      getCall(url = "http://!1!"),
-      requestDataFromList(listOf("example.com"))
+        getCall(url = "http://!1!"),
+        requestDataFromList(listOf("example.com"))
     )
     assertEquals("http://example.com", provider.get())
   }

--- a/extensions/src/test/kotlin/net/devslash/data/ModifiableSupplierTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/data/ModifiableSupplierTest.kt
@@ -8,9 +8,7 @@ import net.devslash.util.getResponse
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Timeout
-import java.util.concurrent.TimeUnit
+import org.junit.Test
 
 internal class ModifiableSupplierTest {
   @Test
@@ -24,8 +22,7 @@ internal class ModifiableSupplierTest {
     assertThat(data.getReplacements()["!1!"], equalTo("B"))
   }
 
-  @Test
-  @Timeout(value = 300, unit = TimeUnit.MILLISECONDS)
+  @Test(timeout = 300)
   fun testEmptyRequestDataReturnsNull() = runBlocking {
     val supplier = ModifiableSupplier(ListDataSupplier(listOf<String>()))
     assertThat(supplier.getDataForRequest(), nullValue())
@@ -44,8 +41,7 @@ internal class ModifiableSupplierTest {
     Unit
   }
 
-  @Test
-  @Timeout(value = 100, unit = TimeUnit.MILLISECONDS)
+  @Test(timeout = 100)
   fun testAddedOnlyReturnedOnce() = runBlocking {
     val supplier = ModifiableSupplier(ListDataSupplier(listOf<String>()))
     supplier.add(ListBasedRequestData(listOf()))

--- a/extensions/src/test/kotlin/net/devslash/it/HttpBounceTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/it/HttpBounceTest.kt
@@ -11,9 +11,9 @@ import io.ktor.server.engine.ApplicationEngine
 import kotlinx.coroutines.runBlocking
 import net.devslash.*
 import net.devslash.pre.SkipIf
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
 
 class HttpBounceTest : ServerTest() {
   override lateinit var appEngine: ApplicationEngine

--- a/extensions/src/test/kotlin/net/devslash/outputs/AppendFileTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/outputs/AppendFileTest.kt
@@ -5,18 +5,19 @@ import net.devslash.util.getBasicRequest
 import net.devslash.util.getResponseWithBody
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.junitpioneer.jupiter.TempDirectory
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import java.io.File
-import java.nio.file.Path
 
 internal class AppendFileTest {
 
+  @Rule
+  val tmpDir = TemporaryFolder()
+
   @Test
-  @ExtendWith(TempDirectory::class)
-  fun testSimpleAppendTest(@TempDirectory.TempDir tmpDir: Path) {
-    val file = File(tmpDir.toFile(), "test.log")
+  fun testSimpleAppendTest() {
+    val file = File(tmpDir.root, "test.log")
     val appender = AppendFile(file.absolutePath)
 
     appender.accept(getBasicRequest(),

--- a/extensions/src/test/kotlin/net/devslash/outputs/AppendFileTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/outputs/AppendFileTest.kt
@@ -13,7 +13,8 @@ import java.io.File
 internal class AppendFileTest {
 
   @Rule
-  val tmpDir = TemporaryFolder()
+  @JvmField
+  public val tmpDir = TemporaryFolder()
 
   @Test
   fun testSimpleAppendTest() {

--- a/extensions/src/test/kotlin/net/devslash/outputs/DebugOutputTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/outputs/DebugOutputTest.kt
@@ -4,7 +4,7 @@ import net.devslash.ListBasedRequestData
 import net.devslash.util.getResponseWithBody
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.jupiter.api.Test
+import org.junit.Test
 
 internal class DebugOutputTest {
   @Test

--- a/extensions/src/test/kotlin/net/devslash/pipes/PipeTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/pipes/PipeTest.kt
@@ -6,7 +6,7 @@ import net.devslash.util.getBasicRequest
 import net.devslash.util.requestDataFromList
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.jupiter.api.Test
+import org.junit.Test
 import java.net.URL
 
 internal class PipeTest {

--- a/extensions/src/test/kotlin/net/devslash/pipes/ResettablePipeTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/pipes/ResettablePipeTest.kt
@@ -6,7 +6,7 @@ import net.devslash.util.getBasicRequest
 import net.devslash.util.requestDataFromList
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.jupiter.api.Test
+import org.junit.Test
 import java.net.URL
 
 internal class ResettablePipeTest {

--- a/extensions/src/test/kotlin/net/devslash/pre/OnceTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/pre/OnceTest.kt
@@ -6,9 +6,9 @@ import net.devslash.util.getBasicRequest
 import net.devslash.util.getCookieJar
 import net.devslash.util.getSessionManager
 import net.devslash.util.requestDataFromList
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.fail
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
 
 internal class OnceTest {
 
@@ -64,7 +64,7 @@ internal class OnceTest {
   @Test
   fun testWorksWithComplexHook() = runBlocking {
     var count = 0
-    val o = Once(object: SessionPersistingBeforeHook {
+    val o = Once(object : SessionPersistingBeforeHook {
       override suspend fun accept(sessionManager: SessionManager,
                                   cookieJar: CookieJar,
                                   req: HttpRequest,

--- a/extensions/src/test/kotlin/net/devslash/pre/SkipIfTest.kt
+++ b/extensions/src/test/kotlin/net/devslash/pre/SkipIfTest.kt
@@ -1,8 +1,8 @@
 package net.devslash.pre
 
 import net.devslash.ListBasedRequestData
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
+import org.junit.Assert.assertTrue
+import org.junit.Test
 
 internal class SkipIfTest {
 

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -2,7 +2,6 @@ val kotlinVersion: String by project
 val ktorVersion: String by project
 
 val junitVersion = "4.12"
-apply(from = "../tests.gradle.kts")
 
 dependencies {
   compile(kotlin("stdlib", kotlinVersion))

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
   testCompile(project(":test-utils"))
+  testCompile("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.0-M1")
   testCompile("io.ktor:ktor-client-mock-jvm:$ktorVersion")
   testCompile("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2")
   testCompile("org.hamcrest:hamcrest-core:1.3")

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -1,7 +1,7 @@
 val kotlinVersion: String by project
 val ktorVersion: String by project
 
-val junitVersion = "5.5.0"
+val junitVersion = "4.12"
 apply(from = "../tests.gradle.kts")
 
 dependencies {
@@ -17,8 +17,7 @@ dependencies {
   implementation("org.apache.httpcomponents:httpclient:4.5")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2")
 
-  testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+  testCompile("junit:junit:$junitVersion")
   testCompile(project(":test-utils"))
   testCompile("io.ktor:ktor-client-mock-jvm:$ktorVersion")
   testCompile("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2")

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -20,7 +20,6 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
   testCompile(project(":test-utils"))
-  testCompile("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.0-M1")
   testCompile("io.ktor:ktor-client-mock-jvm:$ktorVersion")
   testCompile("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2")
   testCompile("org.hamcrest:hamcrest-core:1.3")

--- a/service/src/main/kotlin/net/devslash/HttpSessionManager.kt
+++ b/service/src/main/kotlin/net/devslash/HttpSessionManager.kt
@@ -54,7 +54,12 @@ class HttpSessionManager(val engine: HttpDriver, private val session: Session) :
         }
       }
 
-      channel.send(Envelope(Pair(req, data)))
+      if(channel.offer(Envelope(Pair(req, data)))) {
+        continue
+      } else {
+        println("Blocking")
+        channel.send(Envelope(Pair(req, data)))
+      }
     }
     channel.close()
   }
@@ -112,6 +117,7 @@ class HttpSessionManager(val engine: HttpDriver, private val session: Session) :
                                                  channel: Channel<Envelope<Pair<HttpRequest, RequestData>>>,
                                                  dispatcher: CoroutineContext) = launch(dispatcher) {
     for (next in channel) {
+      println("Accepting next")
       // ensure that this is a valid request
       if (next.shouldProceed()) {
         val contents = next.get()

--- a/service/src/main/kotlin/net/devslash/RateLimiter.kt
+++ b/service/src/main/kotlin/net/devslash/RateLimiter.kt
@@ -1,0 +1,59 @@
+package net.devslash
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+class AcquiringRateLimiter(private val rateLimitOptions: RateLimitOptions, private val clock: Clock = Clock.systemUTC()) {
+  // how many milliseconds between each ticket release
+  // So - 100 tickets per second would be 10 ms Release time
+  private val msRelease: Long = rateLimitOptions.duration.toMillis() / rateLimitOptions.count
+  private val tickets = AtomicInteger(0)
+  private val lastUpdate = clock.instant()
+
+  private val lock = Mutex()
+  private val awaitingTicket = Semaphore(1)
+  // Rolling window - take a number able to be done per 10 seconds and attempt to roll
+
+  suspend fun acquire() {
+    if (!rateLimitOptions.enabled) {
+      return
+    }
+
+    if (lock.tryLock()) {
+      updateInternal()
+      lock.unlock()
+    }
+    awaitingTicket.acquire()
+  }
+
+  private fun updateInternal() {
+    // We only have to do a ticket update when there's an attempt at acquiring.
+    val now = clock.instant()
+    val diff = Duration.between(lastUpdate, now)
+    val steps = diff.toMillis() / msRelease
+    // We only advance `lastUpdate` to the amount that was given by the steps. This avoids us going under the rate limit
+    // by a small margin by a rounding error
+    lastUpdate.plusMillis(steps * msRelease)
+    repeat(steps.toInt()) {
+      awaitingTicket.release()
+    }
+  }
+
+  private suspend fun acquireInternal() {
+    // We know that maximally at one point there is a single thing attempting to get this
+    val current = tickets.getAndDecrement()
+
+    if (current > 0) {
+      // If this is the case then we did get a ticket
+      return
+    }
+    // Otherwise we technically didn't receive a ticket. Due to how this works, this means that there are zero tickets
+    // thus we have to wait for one to accumulate.
+    awaitingTicket.acquire()
+  }
+
+}

--- a/service/src/main/kotlin/net/devslash/RateLimiter.kt
+++ b/service/src/main/kotlin/net/devslash/RateLimiter.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.sync.Mutex
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
+import kotlin.math.max
 
 /**
  * This rate limiter isn't perfect but aims to ensure the rate isn't going too fast, and that the rate is smooth. This
@@ -17,7 +18,7 @@ import java.time.Instant
 class AcquiringRateLimiter(private val rateLimitOptions: RateLimitOptions, private val clock: Clock = Clock.systemUTC()) {
   private var lastRelease = Instant.ofEpochMilli(0)
   // This equals how many milliseconds it takes to release a ticket
-  private val qps = rateLimitOptions.duration.toMillis() / rateLimitOptions.count
+  private val qps = rateLimitOptions.duration.toMillis() / max(1, rateLimitOptions.count)
   private val lock = Mutex()
 
   suspend fun acquire() {

--- a/service/src/test/kotlin/net/devslash/AcquiringRateLimiterTest.kt
+++ b/service/src/test/kotlin/net/devslash/AcquiringRateLimiterTest.kt
@@ -4,21 +4,21 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.withTimeout
-import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
 import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import kotlin.system.measureTimeMillis
-import kotlin.time.measureTime
 
 @ExperimentalCoroutinesApi
 class AcquiringRateLimiterTest {
   private lateinit var tenPerSecond: AcquiringRateLimiter
   private lateinit var clock: FakeClock
 
-  @BeforeEach
+  @Before
   fun setup() {
     clock = FakeClock(Instant.ofEpochMilli(100000))
     tenPerSecond = AcquiringRateLimiter(RateLimitOptions(true, 10, Duration.of(1, ChronoUnit.SECONDS)), clock)
@@ -47,7 +47,7 @@ class AcquiringRateLimiterTest {
         }
       }
 
-      assertTrue(time > 900, "Must take more than 900ms due to smoothing")
+      assertTrue("Must take more than 900ms due to smoothing", time > 900)
     }
   }
 }

--- a/service/src/test/kotlin/net/devslash/AcquiringRateLimiterTest.kt
+++ b/service/src/test/kotlin/net/devslash/AcquiringRateLimiterTest.kt
@@ -1,0 +1,42 @@
+package net.devslash
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@ExperimentalCoroutinesApi
+class AcquiringRateLimiterTest {
+  private lateinit var onePerSecond: AcquiringRateLimiter
+  private lateinit var clock: FakeClock
+
+  @BeforeEach
+  fun setup() {
+    onePerSecond = AcquiringRateLimiter(RateLimitOptions(true, 1, Duration.of(1, ChronoUnit.SECONDS)))
+    clock = FakeClock(Instant.ofEpochMilli(0))
+
+  }
+
+  @Test
+  fun `Second request within rate does not fire`() = runBlockingTest {
+    onePerSecond.acquire()
+    val res = async {
+      runCatching {
+        withTimeout(100) {
+          onePerSecond.acquire()
+        }
+      }
+    }
+    assertEquals(res.await().isFailure, true)
+
+    clock.advance(Duration.ofSeconds(2))
+    onePerSecond.acquire()
+    println("God here")
+  }
+}

--- a/service/src/test/kotlin/net/devslash/AcquiringRateLimiterTest.kt
+++ b/service/src/test/kotlin/net/devslash/AcquiringRateLimiterTest.kt
@@ -1,42 +1,53 @@
 package net.devslash
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.withTimeout
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import kotlin.system.measureTimeMillis
+import kotlin.time.measureTime
 
 @ExperimentalCoroutinesApi
 class AcquiringRateLimiterTest {
-  private lateinit var onePerSecond: AcquiringRateLimiter
+  private lateinit var tenPerSecond: AcquiringRateLimiter
   private lateinit var clock: FakeClock
 
   @BeforeEach
   fun setup() {
-    onePerSecond = AcquiringRateLimiter(RateLimitOptions(true, 1, Duration.of(1, ChronoUnit.SECONDS)))
-    clock = FakeClock(Instant.ofEpochMilli(0))
-
+    clock = FakeClock(Instant.ofEpochMilli(100000))
+    tenPerSecond = AcquiringRateLimiter(RateLimitOptions(true, 10, Duration.of(1, ChronoUnit.SECONDS)), clock)
   }
 
   @Test
   fun `Second request within rate does not fire`() = runBlockingTest {
-    onePerSecond.acquire()
-    val res = async {
-      runCatching {
-        withTimeout(100) {
-          onePerSecond.acquire()
+    assertTrue(tenPerSecond.tryAcquire())
+    assertFalse(tenPerSecond.tryAcquire())
+  }
+
+  @Test
+  fun `Second request fires after allowed`() = runBlockingTest {
+    assertTrue(tenPerSecond.tryAcquire())
+    clock.advance(Duration.ofMillis(1001))
+    assertTrue(tenPerSecond.tryAcquire())
+  }
+
+  @Test
+  fun `Attempt request with timeout`() = runBlocking {
+    // Give a little leeway
+    withTimeout(1200) {
+      val time = measureTimeMillis {
+        repeat(10) {
+          tenPerSecond.acquire()
         }
       }
-    }
-    assertEquals(res.await().isFailure, true)
 
-    clock.advance(Duration.ofSeconds(2))
-    onePerSecond.acquire()
-    println("God here")
+      assertTrue(time > 900, "Must take more than 900ms due to smoothing")
+    }
   }
 }

--- a/service/src/test/kotlin/net/devslash/DefaultHeaderTest.kt
+++ b/service/src/test/kotlin/net/devslash/DefaultHeaderTest.kt
@@ -2,7 +2,7 @@ package net.devslash
 
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.jupiter.api.Test
+import org.junit.Test
 
 class DefaultHeaderTest {
 

--- a/service/src/test/kotlin/net/devslash/FakeClock.kt
+++ b/service/src/test/kotlin/net/devslash/FakeClock.kt
@@ -1,0 +1,24 @@
+package net.devslash
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+
+class FakeClock(var instant: Instant) : Clock() {
+  override fun withZone(zone: ZoneId?): Clock {
+    return this
+  }
+
+  override fun getZone(): ZoneId {
+    return ZoneId.systemDefault()
+  }
+
+  override fun instant(): Instant {
+    return instant;
+  }
+
+  fun advance(d: Duration) {
+    instant = instant.plus(d)
+  }
+}

--- a/service/src/test/kotlin/net/devslash/HttpDriverTest.kt
+++ b/service/src/test/kotlin/net/devslash/HttpDriverTest.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.jupiter.api.Test
+import org.junit.Test
 import java.net.SocketTimeoutException
 
 @ExperimentalCoroutinesApi

--- a/service/src/test/kotlin/net/devslash/HttpDriverTest.kt
+++ b/service/src/test/kotlin/net/devslash/HttpDriverTest.kt
@@ -26,8 +26,8 @@ internal class HttpDriverTest : ServerTest() {
     appEngine = embeddedServer(Netty, serverPort) {
       routing {
         get("/") {
-          delay(1200)
-          call.respond(HttpStatusCode.OK, "")
+          delay(1500)
+          call.respond(HttpStatusCode.OK, "Non_empty")
         }
       }
     }

--- a/service/src/test/kotlin/net/devslash/ListBasedRequestDataTest.kt
+++ b/service/src/test/kotlin/net/devslash/ListBasedRequestDataTest.kt
@@ -2,7 +2,7 @@ package net.devslash
 
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.jupiter.api.Test
+import org.junit.Test
 
 internal class ListBasedRequestDataTest {
 

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -5,5 +5,5 @@ dependencies {
   compile("org.hamcrest:hamcrest-core:1.3")
   compile("io.ktor:ktor-client-mock:1.0.0")
   compile("io.ktor:ktor-server-netty:1.0.0")
-  compile("org.junit-pioneer:junit-pioneer:0.3.0")
+  compile("junit:junit:4.12")
 }

--- a/test-utils/src/main/kotlin/net/devslash/ServerTest.kt
+++ b/test-utils/src/main/kotlin/net/devslash/ServerTest.kt
@@ -4,12 +4,11 @@ import io.ktor.application.Application
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
-import org.junit.jupiter.api.extension.AfterEachCallback
-import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.After
 import java.net.ServerSocket
 import java.util.concurrent.TimeUnit
 
-abstract class ServerTest : AfterEachCallback {
+abstract class ServerTest {
   abstract var appEngine: ApplicationEngine
   protected val serverPort: Int = ServerSocket(0).use { it.localPort }
   protected val address: String = "http://localhost:$serverPort"
@@ -18,8 +17,9 @@ abstract class ServerTest : AfterEachCallback {
     appEngine.start()
   }
 
-  override fun afterEach(context: ExtensionContext?) {
-    appEngine.stop(1000, 100, TimeUnit.MILLISECONDS)
+  @After
+  fun afterEach() {
+    appEngine.stop(1, 1, TimeUnit.MILLISECONDS)
   }
 
   fun runWith(block: Application.() -> Unit) {

--- a/tests.gradle.kts
+++ b/tests.gradle.kts
@@ -1,6 +1,0 @@
-tasks.withType<Test> {
-  useJUnitPlatform()
-  testLogging {
-    events("passed", "skipped", "failed")
-  }
-}

--- a/tests.gradle.kts
+++ b/tests.gradle.kts
@@ -4,7 +4,3 @@ tasks.withType<Test> {
     events("passed", "skipped", "failed")
   }
 }
-
-dependencies {
-//  testImplementation("org.junit.jupiter:junit-jupiter:5.5.2")
-}


### PR DESCRIPTION
The challenge here is to provide a smooth rate rather than spiking at the time unit. It's easy to imagine providing 1,000 tickets per minute or so, then smashing through the tickets in the first few seconds and rate limiting pausing for the rest of the time.

Given that - my aim is to release tickets when they should become available. The other tough part is that the tickets shouldn't live forever. As in it's conceivable that a server is responding slowly to requests, thus tickets would start increasing - then upon the server scaling up - the rate could utilise those older tickets to go above the allowable window. 

In the end - i'm going to follow similar to https://github.com/google/guava/blob/master/guava/src/com/google/common/util/concurrent/SmoothRateLimiter.java#L26