### PR TITLE
Switch to implementation

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
-  compile(kotlin("stdlib", "1.3.30"))
+  implementation(kotlin("stdlib", "1.3.30"))
 
-  compile("org.jetbrains.kotlin:kotlin-stdlib")
+  implementation("org.jetbrains.kotlin:kotlin-stdlib")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2")
 }

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -13,11 +13,11 @@ repositories {
 jmh.jmhVersion = '1.21'
 
 dependencies {
-  compile "org.openjdk.jmh:jmh-core:1.21"
-  compile "org.jetbrains.kotlin:kotlin-stdlib:1.3.30"
-  compile "io.ktor:ktor-server-netty:1.1.4"
+  implementation "org.openjdk.jmh:jmh-core:1.21"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:1.3.30"
+  implementation "io.ktor:ktor-server-netty:1.1.4"
 
-  compile project(":api")
-  compile project(":service")
-  compile project(":extensions")
+  implementation project(":api")
+  implementation project(":service")
+  implementation project(":extensions")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ buildscript {
   project.extra.apply {
     set("kotlinVersion", "1.3.50")
     set("ktorVersion", "1.2.4")
+    set("junitVersion", "4.12")
   }
 
   dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ buildscript {
     set("kotlinVersion", "1.3.50")
     set("ktorVersion", "1.2.4")
     set("junitVersion", "4.12")
+    set("ktorNettyVersion", "1.1.4")
   }
 
   dependencies {

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -1,13 +1,11 @@
-repositories {
-  jcenter()
-}
+val ktorNettyVersion: String by project
 
 dependencies {
   implementation(kotlin("stdlib", "1.3.30"))
   implementation(project(":api"))
   implementation(project(":extensions"))
   implementation(project(":service"))
-  implementation("io.ktor:ktor-server-netty:1.1.4")
+  implementation("io.ktor:ktor-server-netty:$ktorNettyVersion")
 
   implementation("com.google.code.gson:gson:2.3.1")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2")

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -3,11 +3,11 @@ repositories {
 }
 
 dependencies {
-  compile(kotlin("stdlib", "1.3.30"))
-  compile(project(":api"))
-  compile(project(":extensions"))
-  compile(project(":service"))
-  compile("io.ktor:ktor-server-netty:1.1.4")
+  implementation(kotlin("stdlib", "1.3.30"))
+  implementation(project(":api"))
+  implementation(project(":extensions"))
+  implementation(project(":service"))
+  implementation("io.ktor:ktor-server-netty:1.1.4")
 
   implementation("com.google.code.gson:gson:2.3.1")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2")

--- a/extensions/build.gradle.kts
+++ b/extensions/build.gradle.kts
@@ -1,17 +1,16 @@
-repositories {
-  jcenter()
-  maven("http://dl.bintray.com/kotlin/kotlin-eap")
-}
-
 val mockkVersion = "1.9.3"
-val junitVersion = "4.12"
+val junitVersion: String by project
 val kotlinVersion: String by project
+val ktorVersion: String by project
 
 dependencies {
-  compile(kotlin("stdlib", kotlinVersion))
-  compile(kotlin("reflect", kotlinVersion))
-  compile(project(":api"))
-  compile(project(":service"))
+  implementation(kotlin("stdlib", kotlinVersion))
+  implementation(kotlin("reflect", kotlinVersion))
+  implementation(project(":api"))
+  implementation(project(":service"))
+
+  implementation("io.ktor:ktor-client-apache:$ktorVersion")
+  implementation("io.ktor:ktor-client-core:$ktorVersion")
 
   implementation("com.google.code.gson:gson:2.3.1")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2")
@@ -19,9 +18,9 @@ dependencies {
   testImplementation("io.mockk:mockk:$mockkVersion")
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.3.2")
   testImplementation("junit:junit:$junitVersion")
+  testImplementation(project(":test-utils"))
+  testImplementation("org.hamcrest:hamcrest-core:1.3")
 
-  testCompile(project(":test-utils"))
-  testCompile("org.hamcrest:hamcrest-core:1.3")
-  testCompile("io.ktor:ktor-client-mock:1.0.0")
-  testCompile("io.ktor:ktor-server-netty:1.0.0")
+  testImplementation("io.ktor:ktor-client-mock:1.0.0")
+  testImplementation("io.ktor:ktor-server-netty:1.0.0")
 }

--- a/extensions/build.gradle.kts
+++ b/extensions/build.gradle.kts
@@ -2,6 +2,7 @@ val mockkVersion = "1.9.3"
 val junitVersion: String by project
 val kotlinVersion: String by project
 val ktorVersion: String by project
+val ktorNettyVersion: String by project
 
 dependencies {
   implementation(kotlin("stdlib", kotlinVersion))
@@ -22,5 +23,5 @@ dependencies {
   testImplementation("org.hamcrest:hamcrest-core:1.3")
 
   testImplementation("io.ktor:ktor-client-mock:1.0.0")
-  testImplementation("io.ktor:ktor-server-netty:1.0.0")
+  testImplementation("io.ktor:ktor-server-netty:$ktorNettyVersion")
 }

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -1,24 +1,23 @@
 val kotlinVersion: String by project
 val ktorVersion: String by project
-
-val junitVersion = "4.12"
+val junitVersion: String by project
 
 dependencies {
-  compile(kotlin("stdlib", kotlinVersion))
-  compile(project(":api"))
-  compile("io.ktor:ktor-client-core:$ktorVersion")
-  compile("io.ktor:ktor-client-apache:$ktorVersion")
+  implementation(kotlin("stdlib", kotlinVersion))
+  implementation(project(":api"))
+  implementation("io.ktor:ktor-client-core:$ktorVersion")
+  implementation("io.ktor:ktor-client-apache:$ktorVersion")
 
-  compile("com.fasterxml.jackson.core:jackson-core:2.9.8")
-  compile("com.fasterxml.jackson.core:jackson-databind:2.9.8")
-  compile("com.fasterxml.jackson.core:jackson-annotations:2.9.8")
+  implementation("com.fasterxml.jackson.core:jackson-core:2.9.8")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.9.8")
+  implementation("com.fasterxml.jackson.core:jackson-annotations:2.9.8")
 
   implementation("org.apache.httpcomponents:httpclient:4.5")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2")
 
-  testCompile("junit:junit:$junitVersion")
-  testCompile(project(":test-utils"))
-  testCompile("io.ktor:ktor-client-mock-jvm:$ktorVersion")
-  testCompile("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2")
-  testCompile("org.hamcrest:hamcrest-core:1.3")
+  testImplementation("junit:junit:$junitVersion")
+  testImplementation(project(":test-utils"))
+  testImplementation("io.ktor:ktor-client-mock-jvm:$ktorVersion")
+  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2")
+  testImplementation("org.hamcrest:hamcrest-core:1.3")
 }

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -1,12 +1,14 @@
 val kotlinVersion: String by project
 val ktorVersion: String by project
 val junitVersion: String by project
+val ktorNettyVersion: String by project
 
 dependencies {
   implementation(kotlin("stdlib", kotlinVersion))
   implementation(project(":api"))
   implementation("io.ktor:ktor-client-core:$ktorVersion")
   implementation("io.ktor:ktor-client-apache:$ktorVersion")
+  implementation("io.ktor:ktor-server-netty:$ktorNettyVersion")
 
   implementation("com.fasterxml.jackson.core:jackson-core:2.9.8")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.9.8")

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -1,9 +1,11 @@
 val kotlinVersion: String by project
-dependencies {
-  compile(kotlin("stdlib", kotlinVersion))
+val junitVersion: String by project
 
-  compile("org.hamcrest:hamcrest-core:1.3")
-  compile("io.ktor:ktor-client-mock:1.0.0")
-  compile("io.ktor:ktor-server-netty:1.0.0")
-  compile("junit:junit:4.12")
+dependencies {
+  implementation(kotlin("stdlib", kotlinVersion))
+
+  implementation("org.hamcrest:hamcrest-core:1.3")
+  implementation("io.ktor:ktor-client-mock:1.0.0")
+  implementation("io.ktor:ktor-server-netty:1.0.0")
+  implementation("junit:junit:$junitVersion")
 }


### PR DESCRIPTION
`compile` transitively leaks API, i have no need for that. Removing by moving to implementation --> https://stackoverflow.com/questions/44493378/whats-the-difference-between-implementation-and-compile-in-gradle